### PR TITLE
fix(core): declare dayjs runtime dependency

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,19 @@
 # @advjs/core
 
-- Vue Composition API Functions
-- Common Functions
+Core runtime APIs for ADV.JS, including the headless story player and session management.
+
+## Headless playback
+
+```ts
+import { AdvPlayEngine } from '@advjs/core'
+
+const engine = new AdvPlayEngine()
+const output = await engine.loadScript(source, 'story.adv.md')
+
+if (output?.type === 'dialog')
+  console.log(output.text)
+```
+
+Use `next()` and `choose()` to advance the script, `getStatus()` to inspect the current stage, and the session APIs to export or restore progress.
+
+All modules imported by the published runtime are declared in this package's `dependencies`, so consumers do not need to install implementation dependencies separately.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "@advjs/types": "workspace:*",
     "@types/mdast": "catalog:types",
     "consola": "catalog:cli",
+    "dayjs": "catalog:utils",
     "unstorage": "catalog:utils"
   },
   "devDependencies": {

--- a/packages/core/test/package.test.ts
+++ b/packages/core/test/package.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+interface PackageManifest {
+  dependencies?: Record<string, string>
+}
+
+describe('@advjs/core package', () => {
+  it('declares dayjs as a runtime dependency', async () => {
+    const manifestPath = path.resolve(import.meta.dirname, '../package.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as PackageManifest
+
+    expect(manifest.dependencies?.dayjs).toBeDefined()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1649,6 +1649,9 @@ importers:
       consola:
         specifier: catalog:cli
         version: 3.4.2
+      dayjs:
+        specifier: catalog:utils
+        version: 1.11.21
       unstorage:
         specifier: catalog:utils
         version: 1.17.5(db0@0.3.4)(ioredis@5.11.1)


### PR DESCRIPTION
## What changed

- declare dayjs as a runtime dependency of @advjs/core
- add a manifest regression test
- document the public headless AdvPlayEngine entry point

## Why

The published core bundle imports dayjs from its screenshot utility, but consumers installing @advjs/core in isolation do not receive dayjs unless it is declared by the package. Strict pnpm consumers therefore fail before the public runtime can load.

## Validation

- pnpm vitest run packages/core/test
- pnpm build:advjs
- packed @advjs/core manifest contains dayjs