### PR TITLE
chore(core): prepare 0.1.2 release

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,0 +1,55 @@
+name: Release Core
+
+on:
+  push:
+    tags:
+      - 'core-v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-core
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release version
+        run: >-
+          node -e 'const version = require("./packages/core/package.json").version;
+          const tag = process.env.GITHUB_REF_NAME;
+          if (tag !== "core-v" + version)
+          throw new Error("Tag " + tag + " does not match @advjs/core " + version)'
+
+      - name: Test core
+        run: pnpm vitest run packages/core/test
+
+      - name: Build core dependency chain
+        run: pnpm types:build && pnpm parser:build && pnpm core:build
+
+      - name: Pack core
+        run: pnpm -C packages/core pack --pack-destination ../../artifacts
+
+      - name: Publish core
+        run: npm publish artifacts/advjs-core-*.tgz

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@advjs/core",
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Core library for AdvJS, providing essential functionalities and utilities.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/YunYouJun/advjs.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",


### PR DESCRIPTION
## Summary

- bump `@advjs/core` to 0.1.2
- add package repository and public publish metadata
- add an OIDC-ready, tag-gated core-only release workflow

## Verification

- `pnpm vitest run packages/core/test` (29 passed)
- `pnpm types:build && pnpm parser:build && pnpm core:build`
- `pnpm -C packages/core pack --pack-destination ../../artifacts`
- `actionlint .github/workflows/release-core.yml`

The workflow intentionally publishes only the packed core tarball on a matching `core-v*` tag.