### PR TITLE
fix(core): exclude node storage from browser builds

### DIFF
--- a/packages/core/src/engine/session.ts
+++ b/packages/core/src/engine/session.ts
@@ -55,7 +55,11 @@ export class SessionManager {
 
     this.initPromise = (async () => {
       if (isNode()) {
-        const fsDriverModule = await import('unstorage/drivers/fs')
+        // Keep the Node-only driver out of browser dependency graphs. A literal
+        // dynamic import is still pre-bundled by Vite even though this branch is
+        // unreachable in browsers.
+        const fsDriverId = 'unstorage/drivers/fs'
+        const fsDriverModule = await import(/* @vite-ignore */ fsDriverId) as typeof import('unstorage/drivers/fs')
         const fsDriver = fsDriverModule.default
         const home = globalThis.process.env.HOME || '~'
         const sessionBase = this.baseDir || `${home}/.advjs/play-sessions`

--- a/packages/core/test/browser-bundle.test.ts
+++ b/packages/core/test/browser-bundle.test.ts
@@ -1,0 +1,32 @@
+import path from 'node:path'
+import { build } from 'vite'
+import { describe, expect, it } from 'vitest'
+
+describe('@advjs/core browser bundle', () => {
+  it('does not pull the Node-only storage driver into a Vite build', async () => {
+    const result = await build({
+      configFile: false,
+      logLevel: 'silent',
+      build: {
+        lib: {
+          entry: path.resolve(import.meta.dirname, '../src/engine/runtime.ts'),
+          formats: ['es'],
+          name: 'AdvJsCoreBrowserTest',
+        },
+        minify: false,
+        write: false,
+      },
+    })
+
+    const outputs = Array.isArray(result) ? result : [result]
+    const code = outputs.flatMap(output => output.output)
+      .filter(item => item.type === 'chunk')
+      .map(item => item.code)
+      .join('\n')
+
+    expect(code).toContain('AdvPlayEngine = class')
+    expect(code).not.toContain('__vite-browser-external')
+    expect(code).not.toContain('node:fs')
+    expect(code).not.toContain('node:path')
+  })
+})


### PR DESCRIPTION
## Summary

- hide the Node-only unstorage fs driver from Vite browser dependency graphs
- preserve lazy fs-backed sessions in Node
- add a real Vite bundle regression test for the headless browser runtime

## Verification

- `pnpm vitest run packages/core/test` (30 passed)
- `pnpm build:advjs`
- downstream private Vite production build succeeds with the linked core

The downstream contest content remains private; this PR contains only the generic engine fix and regression.