### PR TITLE
ci(core): expose release test failures

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -43,7 +43,7 @@ jobs:
           throw new Error("Tag " + tag + " does not match @advjs/core " + version)'
 
       - name: Test core
-        run: pnpm vitest run packages/core/test
+        run: pnpm vitest run packages/core/test --reporter=default
 
       - name: Build core dependency chain
         run: pnpm types:build && pnpm parser:build && pnpm core:build


### PR DESCRIPTION
## Summary

- force the default Vitest reporter in the core release job
- keep release failures visible in GitHub Actions logs

## Verification

- `actionlint .github/workflows/release-core.yml`
- `CI=1 pnpm vitest run packages/core/test --reporter=default` (30 passed)