### PR TITLE
ci(core): build dependencies before release tests

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -42,11 +42,11 @@ jobs:
           if (tag !== "core-v" + version)
           throw new Error("Tag " + tag + " does not match @advjs/core " + version)'
 
-      - name: Test core
-        run: pnpm vitest run packages/core/test --reporter=default
-
       - name: Build core dependency chain
         run: pnpm types:build && pnpm parser:build && pnpm core:build
+
+      - name: Test core
+        run: pnpm vitest run packages/core/test --reporter=default
 
       - name: Pack core
         run: pnpm -C packages/core pack --pack-destination ../../artifacts


### PR DESCRIPTION
## Summary

- build the core dependency chain before running release tests
- keep browser-bundle coverage active in clean GitHub Actions runners

## Verification

- pnpm types:build
- pnpm parser:build
- pnpm core:build
- pnpm vitest run packages/core/test --reporter=default (30 tests)