### PR TITLE
ci(core): publish packed artifact by local path

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -52,4 +52,4 @@ jobs:
         run: pnpm -C packages/core pack --pack-destination ../../artifacts
 
       - name: Publish core
-        run: npm publish artifacts/advjs-core-*.tgz
+        run: npm publish ./artifacts/advjs-core-*.tgz --provenance --access public


### PR DESCRIPTION
## Summary

- publish the packed tarball through an explicit local path
- request npm provenance and public access for the scoped package

## Verification

- npm publish ./artifacts/advjs-core-0.1.2.tgz --dry-run --provenance --access public