### PR TITLE
feat(character): add shared character catalog package

### DIFF
--- a/packages/character/README.md
+++ b/packages/character/README.md
@@ -1,0 +1,10 @@
+# @advjs/character
+
+`@advjs/character` is the public character-domain entry point for ADV.JS applications. It reuses the canonical `.character.md` types, runtime schemas and parser, then adds an immutable catalog with duplicate-id and relationship validation.
+
+```ts
+import { parseCharacterCatalog } from '@advjs/character'
+
+const catalog = parseCharacterCatalog(characterSources)
+const songJiang = catalog.require('song-jiang')
+```

--- a/packages/character/build.config.ts
+++ b/packages/character/build.config.ts
@@ -1,0 +1,9 @@
+import { defineBuildConfig } from 'unbuild'
+import pkg from './package.json'
+
+export default defineBuildConfig({
+  entries: ['src/index'],
+  clean: true,
+  declaration: 'node16',
+  externals: Object.keys(pkg.dependencies),
+})

--- a/packages/character/package.json
+++ b/packages/character/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@advjs/character",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Shared character schema, Markdown parser and catalog utilities for ADV.JS projects.",
+  "author": {
+    "name": "YunYouJun",
+    "email": "me@yunyoujun.cn",
+    "url": "https://www.yunyoujun.cn"
+  },
+  "license": "MPL-2.0",
+  "homepage": "https://advjs.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/YunYouJun/advjs"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": "^22.12.0 || ^24.0.0"
+  },
+  "scripts": {
+    "build": "unbuild",
+    "dev": "unbuild --stub",
+    "test": "vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@advjs/parser": "workspace:0.1.2",
+    "@advjs/types": "workspace:0.1.2"
+  },
+  "devDependencies": {
+    "unbuild": "catalog:build",
+    "vitest": "catalog:test"
+  }
+}

--- a/packages/character/package.json
+++ b/packages/character/package.json
@@ -41,8 +41,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@advjs/parser": "workspace:0.1.2",
-    "@advjs/types": "workspace:0.1.2"
+    "@advjs/parser": "workspace:^0.1.2",
+    "@advjs/types": "workspace:^0.1.2"
   },
   "devDependencies": {
     "unbuild": "catalog:build",

--- a/packages/character/src/catalog.ts
+++ b/packages/character/src/catalog.ts
@@ -1,0 +1,97 @@
+import type { AdvCharacter } from '@advjs/types'
+import { CharacterFrontmatterSchema, formatCharacterFrontmatterError, parseCharacterMd } from '@advjs/parser'
+
+export interface CharacterSource {
+  /** Identifier used in diagnostics, usually the source file path. */
+  source: string
+  content: string
+}
+
+export interface CreateCharacterCatalogOptions {
+  /** Reject relationships pointing at characters outside this catalog. */
+  validateRelationships?: boolean
+}
+
+/** Immutable, validated character collection shared by editors and consumers. */
+export class CharacterCatalog {
+  readonly #characters: readonly AdvCharacter[]
+  readonly #byId: ReadonlyMap<string, AdvCharacter>
+
+  constructor(characters: readonly AdvCharacter[], options: CreateCharacterCatalogOptions = {}) {
+    const byId = new Map<string, AdvCharacter>()
+
+    for (const character of characters) {
+      const result = CharacterFrontmatterSchema.safeParse(character)
+      if (!result.success) {
+        throw new Error(
+          `Invalid character "${character.id || '<unknown>'}":\n${formatCharacterFrontmatterError(result.error)}`,
+        )
+      }
+      if (byId.has(character.id))
+        throw new Error(`Duplicate character id "${character.id}"`)
+      byId.set(character.id, Object.freeze({ ...character }))
+    }
+
+    if (options.validateRelationships !== false) {
+      for (const character of byId.values()) {
+        for (const relationship of character.relationships ?? []) {
+          if (!byId.has(relationship.targetId)) {
+            throw new Error(
+              `Character "${character.id}" references missing character "${relationship.targetId}"`,
+            )
+          }
+        }
+      }
+    }
+
+    this.#characters = Object.freeze([...byId.values()])
+    this.#byId = byId
+  }
+
+  get size(): number {
+    return this.#characters.length
+  }
+
+  list(): readonly AdvCharacter[] {
+    return this.#characters
+  }
+
+  has(id: string): boolean {
+    return this.#byId.has(id)
+  }
+
+  get(id: string): AdvCharacter | undefined {
+    return this.#byId.get(id)
+  }
+
+  require(id: string): AdvCharacter {
+    const character = this.get(id)
+    if (!character)
+      throw new Error(`Unknown character id "${id}"`)
+    return character
+  }
+}
+
+export function createCharacterCatalog(
+  characters: readonly AdvCharacter[],
+  options?: CreateCharacterCatalogOptions,
+): CharacterCatalog {
+  return new CharacterCatalog(characters, options)
+}
+
+export function parseCharacterCatalog(
+  sources: readonly CharacterSource[],
+  options?: CreateCharacterCatalogOptions,
+): CharacterCatalog {
+  const characters = sources.map(({ source, content }) => {
+    try {
+      return parseCharacterMd(content)
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Unable to parse character source "${source}": ${message}`, { cause: error })
+    }
+  })
+
+  return createCharacterCatalog(characters, options)
+}

--- a/packages/character/src/index.ts
+++ b/packages/character/src/index.ts
@@ -1,0 +1,30 @@
+export * from './catalog'
+/**
+ * @packageDocumentation
+ * Shared character entry point for ADV.JS and character-driven applications.
+ */
+export {
+  CharacterAttributesAiSchema,
+  CharacterAttributesSchema,
+  CharacterCustomFieldSchema,
+  CharacterFrontmatterSchema,
+  CharacterGalgameAttrsSchema,
+  CharacterMysteryAttrsSchema,
+  CharacterProfileSchema,
+  CharacterRpgAttrsSchema,
+  CharacterRpgStatsSchema,
+  exportCharacterForAI,
+  formatCharacterFrontmatterError,
+  parseCharacterMd,
+  stringifyCharacterMd,
+} from '@advjs/parser'
+export type { CharacterFrontmatterParsed } from '@advjs/parser'
+export type {
+  AdvCharacter,
+  AdvCharacterAttributes,
+  AdvCharacterBody,
+  AdvCharacterCustomField,
+  AdvCharacterFrontmatter,
+  AdvCharacterRelationship,
+  AdvCharacterTemplate,
+} from '@advjs/types'

--- a/packages/character/test/catalog.test.ts
+++ b/packages/character/test/catalog.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { createCharacterCatalog, parseCharacterCatalog } from '../src'
+
+describe('character catalog', () => {
+  it('parses and indexes character markdown', () => {
+    const catalog = parseCharacterCatalog([
+      {
+        source: 'song-jiang.character.md',
+        content: `---\nid: song-jiang\nname: 宋江\n---\n\n## 性格\n\n沉着重义。\n`,
+      },
+    ])
+
+    expect(catalog.size).toBe(1)
+    expect(catalog.require('song-jiang').personality).toBe('沉着重义。')
+  })
+
+  it('rejects duplicate ids', () => {
+    expect(() => createCharacterCatalog([
+      { id: 'same', name: '甲' },
+      { id: 'same', name: '乙' },
+    ])).toThrow('Duplicate character id')
+  })
+
+  it('rejects dangling relationships by default', () => {
+    expect(() => createCharacterCatalog([
+      {
+        id: 'a',
+        name: '甲',
+        relationships: [{ targetId: 'b', type: '故交' }],
+      },
+    ])).toThrow('references missing character')
+  })
+})

--- a/packages/parser/src/schemas/character.ts
+++ b/packages/parser/src/schemas/character.ts
@@ -94,7 +94,7 @@ export const CharacterAttributesAiSchema = z.object({
  * Structured character attributes (nested under `attributes.*` in frontmatter).
  */
 export const CharacterAttributesSchema = z.object({
-  template: z.enum(['universal', 'galgame', 'rpg']).optional(),
+  template: z.enum(['universal', 'galgame', 'rpg', 'mystery']).optional(),
   profile: CharacterProfileSchema.optional(),
   galgame: CharacterGalgameAttrsSchema.optional(),
   rpg: CharacterRpgAttrsSchema.optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,7 +822,7 @@ importers:
         version: 1.3.0(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-plugin-vue-layouts:
         specifier: catalog:build
-        version: 0.11.0(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
+        version: 0.11.0(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
       vitest:
         specifier: catalog:test
         version: 4.1.9(@types/node@24.13.2)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -879,10 +879,10 @@ importers:
         version: 8.0.2(@capacitor/core@8.3.0)
       '@ionic/vue':
         specifier: 'catalog:'
-        version: 8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
+        version: 8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
       '@ionic/vue-router':
         specifier: 'catalog:'
-        version: 8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
+        version: 8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
       '@mozilla/readability':
         specifier: 'catalog:'
         version: 0.6.0
@@ -939,7 +939,7 @@ importers:
         version: 11.4.6(vue@3.5.39(typescript@5.9.3))
       vue-router:
         specifier: catalog:frontend
-        version: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
       y-indexeddb:
         specifier: 'catalog:'
         version: 9.0.12(yjs@13.6.31)
@@ -991,10 +991,10 @@ importers:
         version: 5.9.3
       unocss:
         specifier: catalog:build
-        version: 66.7.3(@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 66.7.3(@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-vue-components:
         specifier: catalog:build
-        version: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
       vite:
         specifier: ^8.1.0
         version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -1491,10 +1491,10 @@ importers:
         version: 8.0.0
       unocss:
         specifier: catalog:build
-        version: 66.7.3(@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15)))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 66.7.3(@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-vue-components:
         specifier: catalog:build
-        version: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))
+        version: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
       unplugin-vue-markdown:
         specifier: catalog:build
         version: 30.0.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1512,7 +1512,7 @@ importers:
         version: 8.1.4(@nuxt/kit@4.4.8(magicast@0.5.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: catalog:build
-        version: 0.11.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15)))(vue@3.5.39(typescript@5.9.3))
+        version: 0.11.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
       vitefu:
         specifier: 'catalog:'
         version: 1.1.3(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1524,7 +1524,7 @@ importers:
         version: 11.4.6(vue@3.5.39(typescript@5.9.3))
       vue-router:
         specifier: catalog:frontend
-        version: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))
+        version: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
       wrangler:
         specifier: 'catalog:'
         version: 4.120.1(bufferutil@4.1.0)
@@ -1596,6 +1596,22 @@ importers:
       xml2js:
         specifier: catalog:utils
         version: 0.6.2
+
+  packages/character:
+    dependencies:
+      '@advjs/parser':
+        specifier: workspace:0.1.2
+        version: link:../parser
+      '@advjs/types':
+        specifier: workspace:0.1.2
+        version: link:../types
+    devDependencies:
+      unbuild:
+        specifier: catalog:build
+        version: 3.6.1(sass@1.101.0)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3))(vue@3.5.39(typescript@5.9.3))
+      vitest:
+        specifier: catalog:test
+        version: 4.1.9(@types/node@26.0.1)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.0.1)(typescript@5.9.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/client:
     dependencies:
@@ -2156,7 +2172,7 @@ importers:
         version: 0.4.0-beta.13(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(rollup@4.62.2)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))(yaml@2.9.0)
       unplugin-vue-components:
         specifier: catalog:build
-        version: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))
+        version: 32.1.0(@nuxt/kit@3.21.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))
       unplugin-vue-markdown:
         specifier: catalog:build
         version: 30.0.0(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -17171,18 +17187,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ionic/vue-router@8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))':
+  '@ionic/vue-router@8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@ionic/vue': 8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
+      '@ionic/vue': 8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@stencil/core'
       - vue
       - vue-router
 
-  '@ionic/vue@8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))':
+  '@ionic/vue@8.8.12(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@ionic/core': 8.8.12
-      '@stencil/vue-output-target': 0.10.7(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
+      '@stencil/vue-output-target': 0.10.7(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))
       ionicons: 8.0.13
     transitivePeerDependencies:
       - '@stencil/core'
@@ -19205,12 +19221,12 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.44.0
       '@rollup/rollup-win32-x64-msvc': 4.44.0
 
-  '@stencil/vue-output-target@0.10.7(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))':
+  '@stencil/vue-output-target@0.10.7(@stencil/core@4.43.5)(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
       '@stencil/core': 4.43.5
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.6.0(jiti@2.7.0))':
     dependencies:
@@ -19966,30 +19982,6 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin-utils: 0.3.1
       vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  '@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))':
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      '@unocss/config': 66.7.3
-      '@unocss/core': 66.7.3
-      chokidar: 5.0.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
-      unplugin-utils: 0.3.1
-      webpack: 5.105.4(esbuild@0.28.1)
-      webpack-sources: 3.5.0
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - vite
-    optional: true
 
   '@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
@@ -28407,30 +28399,6 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@66.7.3(@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@unocss/cli': 66.7.3
-      '@unocss/core': 66.7.3
-      '@unocss/preset-attributify': 66.7.3
-      '@unocss/preset-icons': 66.7.3
-      '@unocss/preset-mini': 66.7.3
-      '@unocss/preset-tagify': 66.7.3
-      '@unocss/preset-typography': 66.7.3
-      '@unocss/preset-uno': 66.7.3
-      '@unocss/preset-web-fonts': 66.7.3
-      '@unocss/preset-wind': 66.7.3
-      '@unocss/preset-wind3': 66.7.3
-      '@unocss/preset-wind4': 66.7.3
-      '@unocss/transformer-attributify-jsx': 66.7.3
-      '@unocss/transformer-compile-class': 66.7.3
-      '@unocss/transformer-directives': 66.7.3
-      '@unocss/transformer-variant-group': 66.7.3
-      '@unocss/vite': 66.7.3(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-    optionalDependencies:
-      '@unocss/webpack': 66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
-    transitivePeerDependencies:
-      - vite
-
   unocss@66.7.3(@unocss/webpack@66.7.3(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15)))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@unocss/cli': 66.7.3
@@ -28566,56 +28534,6 @@ snapshots:
       - vite
       - webpack
 
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)):
-    dependencies:
-      chokidar: 5.0.0
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      obug: 2.1.3
-      picomatch: 4.0.4
-      tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
-      unplugin-utils: 0.3.1
-      vue: 3.5.39(typescript@5.9.3)
-    optionalDependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.3)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - vite
-      - webpack
-
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15)):
-    dependencies:
-      chokidar: 5.0.0
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      obug: 2.1.3
-      picomatch: 4.0.4
-      tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15))
-      unplugin-utils: 0.3.1
-      vue: 3.5.39(typescript@5.9.3)
-    optionalDependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.3)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - vite
-      - webpack
-
   unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)):
     dependencies:
       chokidar: 5.0.0
@@ -28658,7 +28576,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)):
+  unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
@@ -28667,18 +28585,6 @@ snapshots:
       esbuild: 0.28.1
       rolldown: 1.1.3
       rollup: 2.80.0
-      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.105.4(esbuild@0.28.1)
-
-  unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)):
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      esbuild: 0.28.1
-      rolldown: 1.1.3
-      rollup: 4.62.2
       vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       webpack: 5.105.4(esbuild@0.28.1)
 
@@ -29011,13 +28917,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-layouts@0.11.0(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3)):
+  vite-plugin-vue-layouts@0.11.0(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.39(typescript@5.9.3)
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -29298,7 +29204,7 @@ snapshots:
     dependencies:
       vue: 3.5.39(typescript@5.9.3)
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.39(typescript@5.9.3))
@@ -29314,41 +29220,7 @@ snapshots:
       picomatch: 4.0.4
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
-      unplugin-utils: 0.3.1
-      vue: 3.5.39(typescript@5.9.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.39
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
-      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - webpack
-
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(webpack@5.105.4(esbuild@0.28.1)):
-    dependencies:
-      '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.2(vue@3.5.39(typescript@5.9.3))
-      '@vue/devtools-api': 8.1.4
-      ast-walker-scope: 0.9.0
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
+      unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@2.80.0)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
       unplugin-utils: 0.3.1
       vue: 3.5.39(typescript@5.9.3)
       yaml: 2.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,10 +1400,10 @@ importers:
   packages/advjs:
     dependencies:
       '@advjs/client':
-        specifier: workspace:0.1.2
+        specifier: workspace:^0.1.2
         version: link:../client
       '@advjs/core':
-        specifier: workspace:0.1.2
+        specifier: workspace:^0.1.2
         version: link:../core
       '@advjs/devtools':
         specifier: workspace:0.1.2


### PR DESCRIPTION
## Summary

- add the public `@advjs/character` package as the shared character schema/catalog entry point
- validate catalog duplicates and relationships
- use semver workspace ranges so published dependencies resolve from npm

## Verification

- `pnpm --filter @advjs/character build`
- `pnpm --filter @advjs/character test`
- `pnpm exec vitest run packages/parser/test/index.test.ts`